### PR TITLE
Solves #6 - Ensure backend definition is set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,13 @@
+# imguiwrap provides a cmakelists for incorporating imgui into other projects.
+#
+# Currently, it assumes an opengl implementation using the vendored glfw library.
+#
+# This has been the only backend I've had reason to use, and I didn't want to
+# do a half-baked job of introducing support for other backends.
+#
+# Pull-requests that introduce support for selecting one or more alternate backend
+# are welcome.
+#
 cmake_minimum_required(VERSION 3.16)
 
 set (IMGUIWRAP_CXX_STANDARD "17" CACHE STRING "Specify the C++ standard version Imgui will use (must be 17 or higher")
@@ -6,6 +16,11 @@ set (CMAKE_CXX_STANDARD "${IMGUIWRAP_CXX_STANDARD}")
 set (CMAKE_CXX_STANDARD_REQUIRED ON)
 
 project("imguiwrap")
+
+set (IMGUIWRAP_BACKEND "GL3W" CACHE STRING "Specify the imgui backend")
+if (IMGUIWRAP_BACKEND STREQUAL "GL3W")
+	add_compile_definitions(IMGUI_IMPL_OPENGL_LOADER_GL3W)
+endif ()
 
 add_subdirectory(vendor)
 


### PR DESCRIPTION
If the backend is unspecified, imgui will do a simple linear check to see which glewalike to use, starting with glew. This is fine in a simple container with the minimum required installs, but if your system has glew it will make the wrong selection.

So this change introduces a CMakeLists.txt parameter to make users aware that there is a choice to be had, but then hardcodes it to a simple default.