### PR TITLE
Changed compiler check to be more accurate

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,15 +53,17 @@ target_link_libraries(
 	imgui
 )
 
-if (WIN32)
+if (MSVC)
 	string (REGEX REPLACE "/EH[a-z]+-?" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 	set (IMGW_NO_EXCEPTIONS /EHc-)
 	set (IMGW_ALL_WARNINGS  /W3)
 	set (IMGW_NO_RTTI /GR-)
-else ()
+elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
 	set (IMGW_NO_EXCEPTIONS -fno-exceptions)
 	set (IMGW_ALL_WARNINGS  -Wall -Werror -Wextra -Wpedantic)
 	set (IMGW_NO_RTTI -fno-rtti)
+else ()
+	message (WARNING "CMAKE_CXX_FLAGS not set for compiler ${CMAKE_CXX_COMPILER_ID}")
 endif ()
 
 target_compile_options(imguiwrap PRIVATE ${IMGW_NO_RTTI} ${IMGW_NO_EXCEPTIONS} ${IMGW_ALL_WARNINGS})


### PR DESCRIPTION
Right now src/CMakeLists.txt assumes that if we're in a Windows environment, that we must be compiling with MSVC. 
This change removes that assumption and checks the compiler itself to set the flags, as MinGW sets WIN32 but uses GCC/Clang as the compiler.