### PR TITLE
Add support for ImGui's docking branch, which includes Multi Viewports, if available

### DIFF
--- a/src/imguiwrap.h
+++ b/src/imguiwrap.h
@@ -39,6 +39,25 @@ struct ImGuiWrapConfig
 
     // startDark_ enables StyleColorsDark after creating the window.
     bool startDark_{true};
+
+#ifdef IMGUI_HAS_DOCK
+	// enableDocking_ enables windows to dock with each other
+	bool enableDocking_{false};
+#endif
+
+#ifdef IMGUI_HAS_VIEWPORT
+	// enableViewport_ enables windows to be pulled out of the main window and exist independently
+	bool enableViewport_{false};
+
+	// enableViewportAutoMerge_ lets windows merge with the main window if dragged within its bounds.
+	// Disabling this forces the windows to be independent
+	bool enableViewportAutoMerge_{true};
+
+	// hideMainWindow_ sets the main window to be invisible.
+	// This is only useful if enableViewportAutoMerge_ is false as otherwise nothing is displayed
+	/// TODO: Perhaps enforce this in code somewhere?
+	bool hideMainWindow_{false};
+#endif
 };
 
 // imgui_main implements a main-loop that constructs a GL window and calls the supplied


### PR DESCRIPTION
Adds a few config options to let the user enable these features, disabled by default to not change existing behavior. Config options named to match the naming style of other options but feel free to make changes if needed. I also added some todo comments for parts where I wasn't sure if I should change.
For issue #14 